### PR TITLE
build: fix format command on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "copy:readme": "copyfiles README.md dist/lib",
     "generate:prerender": "node dist/prerender.js",
     "webpack:server": "webpack --config webpack.server.config.js --progress --colors",
-    "format:base": "prettier '{src,cypress}/**/*{.ts,.js,.json}'",
+    "format:base": "prettier \"{src,cypress}/**/*{.ts,.js,.json}\"",
     "format:check": "npm run format:base -- --list-different",
     "format:fix": "npm run format:base -- --write",
     "style": "npm run lint:check && npm run format:check",


### PR DESCRIPTION
When running the format command on a windows machine, the following error is thrown:

`[error] No matching files. Patterns tried: '{src,cypress}/**/*{.ts,.js,.json}' !**/node_modules/** !./node_modules/**`.

