### PR TITLE
fix: remove peer dependency on cdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ You can also fiddle with the library using [StackBlitz](https://stackblitz.com/e
 ## Installation
 
 ```
-npm install ngx-drag-to-select @angular/cdk
+npm install ngx-drag-to-select
 ```
 
 or
 
 ```
-yarn add ngx-drag-to-select @angular/cdk
+yarn add ngx-drag-to-select
 ```
 
 ## Setup

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -7,7 +7,6 @@
   "peerDependencies": {
     "@angular/core": ">=5.0.0",
     "@angular/common": ">=5.0.0",
-    "@angular/cdk": ">=5.0.0",
     "rxjs": ">=5.5.0"
   },
   "ngPackage": {

--- a/src/lib/src/drag-to-select.module.ts
+++ b/src/lib/src/drag-to-select.module.ts
@@ -1,6 +1,5 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PlatformModule } from '@angular/cdk/platform';
 
 import { SelectContainerComponent } from './select-container.component';
 import { SelectItemDirective } from './select-item.directive';
@@ -17,7 +16,7 @@ export function CONFIG_FACTORY(config: Partial<DragToSelectConfig>) {
 }
 
 @NgModule({
-  imports: [CommonModule, PlatformModule],
+  imports: [CommonModule],
   declarations: [...COMPONENTS],
   exports: [...COMPONENTS]
 })

--- a/src/lib/src/select-container.component.ts
+++ b/src/lib/src/select-container.component.ts
@@ -11,10 +11,11 @@ import {
   ContentChildren,
   QueryList,
   HostBinding,
-  AfterViewInit
+  AfterViewInit,
+  PLATFORM_ID,
+  Inject
 } from '@angular/core';
-
-import { Platform } from '@angular/cdk/platform';
+import { isPlatformBrowser } from '@angular/common';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -33,8 +34,7 @@ import {
   mapTo,
   share,
   withLatestFrom,
-  distinctUntilChanged,
-  startWith
+  distinctUntilChanged
 } from 'rxjs/operators';
 
 import { SelectItemDirective } from './select-item.directive';
@@ -93,15 +93,15 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   constructor(
+    @Inject(PLATFORM_ID) private platformId,
     private shortcuts: ShortcutService,
-    private platform: Platform,
     private hostElementRef: ElementRef,
     private renderer: Renderer2,
     private ngZone: NgZone
   ) {}
 
   ngAfterViewInit() {
-    if (this.platform.isBrowser) {
+    if (isPlatformBrowser(this.platformId)) {
       this.host = this.hostElementRef.nativeElement;
 
       this.initProxy();

--- a/src/lib/src/select-item.directive.ts
+++ b/src/lib/src/select-item.directive.ts
@@ -1,5 +1,5 @@
-import { Platform } from '@angular/cdk/platform';
-import { Directive, DoCheck, ElementRef, Inject, Input, OnInit, Renderer2 } from '@angular/core';
+import { Directive, DoCheck, ElementRef, Inject, Input, OnInit, Renderer2, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { DragToSelectConfig } from './models';
 import { CONFIG } from './tokens';
 import { calculateBoundingClientRect } from './utils';
@@ -24,13 +24,13 @@ export class SelectItemDirective implements OnInit, DoCheck {
 
   constructor(
     @Inject(CONFIG) private config: DragToSelectConfig,
-    private platform: Platform,
+    @Inject(PLATFORM_ID) private platformId,
     private host: ElementRef,
     private renderer: Renderer2
   ) {}
 
   ngOnInit() {
-    if (this.platform.isBrowser) {
+    if (isPlatformBrowser(this.platformId)) {
       setTimeout(() => this.calculateBoundingClientRect());
     }
   }


### PR DESCRIPTION
Thanks for this great library! When reading the source I noticed the CDK was only used for checking if running in the browser, rather than using a whole dependency for this there is a core angular method for determining if running in a browser