### PR TITLE
feat: expose update as part of the public api

### DIFF
--- a/src/lib/src/select-container.component.ts
+++ b/src/lib/src/select-container.component.ts
@@ -203,6 +203,11 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  update() {
+    this.calculateBoundingClientRect();
+    this.$selectableItems.forEach(item => item.calculateBoundingClientRect());
+  }
+
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();
@@ -251,11 +256,6 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
           this.update();
         });
     });
-  }
-
-  private update() {
-    this.calculateBoundingClientRect();
-    this.$selectableItems.forEach(item => item.calculateBoundingClientRect());
   }
 
   private calculateBoundingClientRect() {

--- a/src/lib/src/select-container.spec.ts
+++ b/src/lib/src/select-container.spec.ts
@@ -1,8 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { DragToSelectModule } from './drag-to-select.module';
 import { SelectContainerComponent } from './select-container.component';
 import { By } from '@angular/platform-browser';
+import { SelectItemDirective } from './select-item.directive';
 
 function triggerDomEvent(eventType: string, target: HTMLElement | Element, eventData: object = {}): void {
   const event: Event = document.createEvent('Event');
@@ -14,11 +15,13 @@ function triggerDomEvent(eventType: string, target: HTMLElement | Element, event
 @Component({
   template: `
     <ngx-select-container>
-      <span selectItem>Select me!</span>
+      <span selectItem #selectItem="selectItem">Select me!</span>
     </ngx-select-container>
   `
 })
-class TestComponent {}
+class TestComponent {
+  @ViewChild('selectItem') selectItem: SelectItemDirective;
+}
 
 describe('SelectContainerComponent', () => {
   let component: TestComponent;
@@ -39,7 +42,16 @@ describe('SelectContainerComponent', () => {
   });
 
   it('should not throw when clicking the element immediately on creation', () => {
-    const selectContainer = fixture.debugElement.query(By.directive(SelectContainerComponent)).nativeElement;
-    expect(() => triggerDomEvent('mousedown', selectContainer)).not.toThrowError();
+    const selectContainer = fixture.debugElement.query(By.directive(SelectContainerComponent));
+    expect(() => triggerDomEvent('mousedown', selectContainer.nativeElement)).not.toThrowError();
+  });
+
+  it('should expose update as part of the public api', () => {
+    const selectContainer = fixture.debugElement.query(By.directive(SelectContainerComponent));
+    jest.spyOn(selectContainer.componentInstance as SelectContainerComponent, 'calculateBoundingClientRect');
+    jest.spyOn(fixture.componentInstance.selectItem, 'calculateBoundingClientRect');
+    selectContainer.componentInstance.update();
+    expect(selectContainer.componentInstance.calculateBoundingClientRect).toHaveBeenCalled();
+    expect(fixture.componentInstance.selectItem.calculateBoundingClientRect).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
I have a use case where I have the following structure:

```
<ngx-select-container #selectContainer="ngx-select-container">

 <fixed-items>Inside are selectable items</fixed-items>

 <scrollable-container>Inside are more selectable items</scrollable-container>

</ngx-select-container>
```

If I scroll the `scrollable-container` component then the drag to select doesn't work properly. I can mitigate this by simply adding `(scroll)="selectContainer.update()"` to the `scrollable-container` component which will force all the positioning to be updated. At the moment this method is marked as a private API, would you consider making this public? (maybe there's a more verbose name for it as well?)