### PR TITLE
fix: prevent error when clicking on the container on first load

### DIFF
--- a/src/lib/src/select-container.component.ts
+++ b/src/lib/src/select-container.component.ts
@@ -34,7 +34,8 @@ import {
   mapTo,
   share,
   withLatestFrom,
-  distinctUntilChanged
+  distinctUntilChanged,
+  startWith
 } from 'rxjs/operators';
 
 import { SelectItemDirective } from './select-item.directive';
@@ -106,6 +107,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
 
       this.initProxy();
 
+      this.calculateBoundingClientRect();
       this.observeBoundingRectChanges();
       this.observeSelectableItems();
 
@@ -237,16 +239,13 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
   }
 
   private observeBoundingRectChanges() {
-    // Initialize client bounding rect
-    setTimeout(() => this.calculateBoundingClientRect());
-
     this.ngZone.runOutsideAngular(() => {
       const resize$ = fromEvent(window, 'resize');
       const windowScroll$ = fromEvent(window, 'scroll');
       const containerScroll$ = fromEvent(this.host, 'scroll');
 
       merge(resize$, windowScroll$, containerScroll$)
-        .pipe(auditTime(AUDIT_TIME), takeUntil(this.destroy$))
+        .pipe(startWith('INITIAL_UPDATE'), auditTime(AUDIT_TIME), takeUntil(this.destroy$))
         .subscribe(() => {
           this.update();
         });

--- a/src/lib/src/select-container.spec.ts
+++ b/src/lib/src/select-container.spec.ts
@@ -1,0 +1,45 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { DragToSelectModule } from './drag-to-select.module';
+import { SelectContainerComponent } from './select-container.component';
+import { By } from '@angular/platform-browser';
+
+function triggerDomEvent(eventType: string, target: HTMLElement | Element, eventData: object = {}): void {
+  const event: Event = document.createEvent('Event');
+  Object.assign(event, eventData);
+  event.initEvent(eventType, true, true);
+  target.dispatchEvent(event);
+}
+
+@Component({
+  template: `
+    <ngx-select-container>
+      <span selectItem>Select me!</span>
+    </ngx-select-container>
+  `
+})
+class TestComponent {}
+
+describe('SelectContainerComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [DragToSelectModule.forRoot()]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    window.getSelection = jest.fn().mockReturnValue({});
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should not throw when clicking the element immediately on creation', () => {
+    const selectContainer = fixture.debugElement.query(By.directive(SelectContainerComponent)).nativeElement;
+    expect(() => triggerDomEvent('mousedown', selectContainer)).not.toThrowError();
+  });
+});

--- a/src/lib/src/select-item.directive.ts
+++ b/src/lib/src/select-item.directive.ts
@@ -31,7 +31,7 @@ export class SelectItemDirective implements OnInit, DoCheck {
 
   ngOnInit() {
     if (isPlatformBrowser(this.platformId)) {
-      setTimeout(() => this.calculateBoundingClientRect());
+      this.calculateBoundingClientRect();
     }
   }
 


### PR DESCRIPTION
If you click on the container before
```
ngOnInit() {
    if (isPlatformBrowser(this.platformId)) {
      setTimeout(() => this.calculateBoundingClientRect());
    }
  }
```

has the chance to run you'll get an error like this:
![image](https://user-images.githubusercontent.com/6425649/42123994-646095f0-7c53-11e8-99a4-df38e1653900.png)

I wasn't too sure how to write a test for this, I don't think it's possible to with cypress. Any guidance would be helpful 😄 