### PR TITLE
feat: add way of toggling items with shortcut click only

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,14 +204,15 @@ When using `meta`, it will be substituted with `ctrl` (for Windows) **and** `cmd
 
 **Inputs**
 
-| Input         | Type       | Default | Description                                                                                                   |
-| ------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------- |
-| selectedItems | Array<any> | /       | Collection of items that are currently selected                                                               |
-| selectOnDrag  | Boolean    | `true`  | Whether items should be selected while dragging                                                               |
-| disabled      | Boolean    | `false` | Disable selection                                                                                             |
-| disableDrag   | Boolean    | `false` | Disable selection by dragging with the mouse. May be useful for mobile.                                       |
-| selectMode    | Boolean    | `false` | If set to `true`, a _toggle_ mode is activated similar to the `toggleSingleItem` shortcut. Useful for mobile. |
-| custom        | Boolean    | `false` | If set to `true`, all default styles for selected items will not be applied.                                  |
+| Input                 | Type       | Default | Description                                                                                                   |
+| --------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| selectedItems         | Array<any> | /       | Collection of items that are currently selected                                                               |
+| selectOnDrag          | Boolean    | `true`  | Whether items should be selected while dragging                                                               |
+| disabled              | Boolean    | `false` | Disable selection                                                                                             |
+| disableDrag           | Boolean    | `false` | Disable selection by dragging with the mouse. May be useful for mobile.                                       |
+| selectMode            | Boolean    | `false` | If set to `true`, a _toggle_ mode is activated similar to the `toggleSingleItem` shortcut. Useful for mobile. |
+| custom                | Boolean    | `false` | If set to `true`, all default styles for selected items will not be applied.                                  |
+| selectWithShortcut    | Boolean    | `false` | If set to `true`, items can only be selected when single clicking and applying a keyboard shortcut
 
 Here's an example of all inputs in action:
 

--- a/cypress/integration/demo-page.spec.ts
+++ b/cypress/integration/demo-page.spec.ts
@@ -16,7 +16,8 @@ import {
   getDeleteButton,
   getSelectAllButton,
   shouldBeInSelectMode,
-  getSelectCount
+  getSelectCount,
+  enableSelectWithShortcut
 } from '../support/utils';
 
 import { NO_SELECT_CLASS } from '../../src/lib/src/constants';
@@ -130,6 +131,19 @@ describe('Desktop', () => {
           .shouldSelect([2])
           .get(`.${SELECTED_CLASS}`)
           .should('have.length', 1);
+      });
+    });
+
+    it('should not select a single item when selectWithShortcut is true', () => {
+      getDesktopExample().within(() => {
+        enableSelectWithShortcut();
+        cy
+          .getSelectItem(0)
+          .dispatch('mousedown')
+          .dispatch('mouseup')
+          .shouldSelect([])
+          .get(`.${SELECTED_CLASS}`)
+          .should('have.length', 0);
       });
     });
 

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -60,6 +60,10 @@ export const disableSelection = () => {
   return cy.get('[cy-data="disable"]').click();
 };
 
+export const enableSelectWithShortcut = () => {
+  return cy.get('[cy-data="selectWithShortcut"]').click();
+};
+
 export const selectAll = () => {
   return getSelectAllButton().click();
 };

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,13 +27,14 @@
     <mat-checkbox cy-data="selectOnDrag" [(ngModel)]="selectOnDrag">Select on Drag</mat-checkbox>
     <mat-checkbox cy-data="disable" [(ngModel)]="disable">Disable</mat-checkbox>
     <mat-checkbox cy-data="selectMode" [(ngModel)]="selectMode">Select Mode</mat-checkbox>
+    <mat-checkbox cy-data="selectWithShortcut" [(ngModel)]="selectWithShortcut">Select with Shortcut</mat-checkbox>
 
     <button cy-data="selectAll" mat-raised-button (click)="selectContainer.selectAll()">Select All</button>
     <button cy-data="clearSelection" mat-raised-button (click)="selectContainer.clearSelection()">Clear Selection</button>
 
     <div class="drag-area">
       <ngx-select-container #selectContainer="ngx-select-container" [selectMode]="selectMode" [(selectedItems)]="selectedDocuments"
-        [disabled]="disable" [selectOnDrag]="selectOnDrag" (select)="onSelect($event)">
+        [disabled]="disable" [selectOnDrag]="selectOnDrag" [selectWithShortcut]="selectWithShortcut" (select)="onSelect($event)">
         <mat-grid-list cols="4" rowHeight="200px" gutterSize="20px">
           <mat-grid-tile [selectItem]="document" *ngFor="let document of documents">
             {{ document.name }}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,6 +17,7 @@ export class AppComponent implements OnInit {
   selectMode = false;
   disable = false;
   isDesktop = false;
+  selectWithShortcut = false;
 
   constructor(
     private titleService: Title,

--- a/src/lib/src/select-container.component.ts
+++ b/src/lib/src/select-container.component.ts
@@ -80,6 +80,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
   @Input() disabled = false;
   @Input() disableDrag = false;
   @Input() selectMode = false;
+  @Input() selectWithShortcut = false;
 
   @Input()
   @HostBinding('class.ngx-custom')
@@ -293,14 +294,20 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
       }
 
       const shouldAdd =
-        (withinBoundingBox && !this.shortcuts.toggleSingleItem(event) && !this.selectMode) ||
+        (withinBoundingBox &&
+          !this.shortcuts.toggleSingleItem(event) &&
+          !this.selectMode &&
+          !this.selectWithShortcut) ||
         (withinBoundingBox && this.shortcuts.toggleSingleItem(event) && !item.selected) ||
         (!withinBoundingBox && this.shortcuts.toggleSingleItem(event) && item.selected) ||
         (withinBoundingBox && !item.selected && this.selectMode) ||
         (!withinBoundingBox && item.selected && this.selectMode);
 
       const shouldRemove =
-        (!withinBoundingBox && !this.shortcuts.toggleSingleItem(event) && !this.selectMode) ||
+        (!withinBoundingBox &&
+          !this.shortcuts.toggleSingleItem(event) &&
+          !this.selectMode &&
+          !this.selectWithShortcut) ||
         (!withinBoundingBox && this.shortcuts.toggleSingleItem(event) && !item.selected) ||
         (withinBoundingBox && this.shortcuts.toggleSingleItem(event) && item.selected) ||
         (!withinBoundingBox && !item.selected && this.selectMode) ||


### PR DESCRIPTION
My usecase is that I have a series of selectable items that have click handlers already + are also draggable. I would therefore need a way to only allow selecting these items on click if holding down the shortcut key, so that the normal click + drag handlers can fire as normal. The option name could probably use some bikeshedding 😄 