### PR TITLE
feat(lib): add ability to programatically select, deselect and toggle items

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,14 @@ Example:
 
 **Public Methods**
 
-| Methods        | Description                                                 |
-| -------------- | ----------------------------------------------------------- |
-| selectAll      | Select all items within the drag area                       |
-| clearSelection | Clear current selection                                     |
-| update         | Recalculate bounding box for the container and its children |
+| Methods                                               | Description                                                 |
+| ----------------------------------------------------- | ----------------------------------------------------------- |
+| selectAll()                                           | Select all items within the drag area                       |
+| clearSelection()                                      | Clear current selection                                     |
+| update()                                              | Recalculate bounding box for the container and its children |
+| <a href="#selectItems">selectItems(predicate)</a>     | Select all items `predicate` returns truthy for             |
+| <a href="#deselectItems">deselectItems(predicate)</a> | Deselect all items `predicate` returns truthy for           |
+| <a href="#toggleItems">toggleItems(predicate)</a>     | Toggle all items `predicate` returns truthy for             |
 
 To access these methods on the container component you can either use the `@ViewChild()` decorator
 
@@ -350,14 +353,92 @@ export class AppComponent {
 }
 ```
 
+#### <a id="selectItems"></a> `selectItems(predicate)`
+
+Iterates over collection of `SelectItemDirective`'s, selecting all items from that collection that meet the condition specified in the `predicate` function. The `predicate` is invoked with one argument `item`, which is equivalent to the value returned by `SelectItemDirective.value`.
+
+**Arguments**
+
+`predicate ((item: T) => boolean)`: The function invoked per iteration.
+
+**Example**
+
+```
+import { Component, ViewChild } from '@angular/core';
+import { SelectContainerComponent } from 'ngx-drag-to-select';
+
+@Component({
+  ...
+})
+export class AppComponent {
+  @ViewChild(SelectContainerComponent) selectContainer: SelectContainerComponent;
+
+  someMethod() {
+    this.selectContainer.selectItems(item => item.id === 1)
+  }
+}
+```
+
+#### <a id="deselectItems"></a> `deselectItems(predicate)`
+
+Iterates over collection of `SelectItemDirective`'s, deselecting all items from that collection that meet the condition specified in the `predicate` function. The `predicate` is invoked with one argument `item`, which is equivalent to the value returned by `SelectItemDirective.value`.
+
+**Arguments**
+
+`predicate ((item: T) => boolean)`: The function invoked per iteration.
+
+**Example**
+
+```
+import { Component, ViewChild } from '@angular/core';
+import { SelectContainerComponent } from 'ngx-drag-to-select';
+
+@Component({
+  ...
+})
+export class AppComponent {
+  @ViewChild(SelectContainerComponent) selectContainer: SelectContainerComponent;
+
+  someMethod() {
+    this.selectContainer.deselectItems(item => item.id === 1)
+  }
+}
+```
+
+#### <a id="toggleItems"></a> `toggleItems(predicate)`
+
+Iterates over collection of `SelectItemDirective`'s, toggling all items from that collection that meet the condition specified in the `predicate` function. The `predicate` is invoked with one argument `item`, which is equivalent to the value returned by `SelectItemDirective.value`.
+
+**Arguments**
+
+`predicate ((item: T) => boolean)`: The function invoked per iteration.
+
+**Example**
+
+```
+import { Component, ViewChild } from '@angular/core';
+import { SelectContainerComponent } from 'ngx-drag-to-select';
+
+@Component({
+  ...
+})
+export class AppComponent {
+  @ViewChild(SelectContainerComponent) selectContainer: SelectContainerComponent;
+
+  someMethod() {
+    this.selectContainer.toggleItems(item => [1, 2, 3].includes(item.id))
+  }
+}
+```
+
 ### `dtsSelectItem`
 
 The `dtsSelectItem` directive is used to mark DOM elements as selectable items. It takes an input to control the value that is used when the item was selected. If the input is not specified, it will use the directive instance as a default value.
 
 **Inputs**
 
-| Input      | Type | Default            | Description                                  |
-| ---------- | ---- | ------------------ | -------------------------------------------- |
+| Input         | Type | Default            | Description                                  |
+| ------------- | ---- | ------------------ | -------------------------------------------- |
 | dtsSelectItem | any  | Directive Instance | Value that is used when the item is selected |
 
 Example:

--- a/projects/ngx-drag-to-select/src/lib/models.ts
+++ b/projects/ngx-drag-to-select/src/lib/models.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs';
 import { SelectItemDirective } from './select-item.directive';
 
+export type PredicateFn<T> = (item: T) => boolean;
+
 export enum UpdateActions {
   Add,
   Remove

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,8 +22,8 @@ export class AppComponent implements OnInit {
   constructor(
     private titleService: Title,
     private breakpointObserver: BreakpointObserver,
-    private iconRegistry: MatIconRegistry,
-    private sanitizer: DomSanitizer
+    iconRegistry: MatIconRegistry,
+    sanitizer: DomSanitizer
   ) {
     iconRegistry.addSvgIcon('apple', sanitizer.bypassSecurityTrustResourceUrl('assets/apple-icon.svg'));
     iconRegistry.addSvgIcon('windows', sanitizer.bypassSecurityTrustResourceUrl('assets/windows-icon.svg'));


### PR DESCRIPTION
Adds `selectItems()`, `deselectItems()` and `toggleItems()`, each method takes in a predicate that is called on every item. If the predicate returns `true` it will perform the desired action on the element.

Closes #46