### PR TITLE
feat(lib): add select and deselect output

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,16 @@ Here's an example of all inputs in action:
 
 **Outputs**
 
-| Input  | Payload Type | Description                                                                                                    |
-| ------ | ------------ | -------------------------------------------------------------------------------------------------------------- |
-| select | Array<any>   | Event that is fired whenever the selection changes. The payload (`$event`) will be the list of selected items. |
+| Input          | Payload Type | Description                                                                                                |
+| -------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
+| select         | Array<any>   | Event that is fired when the selection changes. The payload (`$event`) will be the list of selected items. |
+| itemSelected   | any          | Event that is fired when the item is selected. The payload (`$event`) will be the item's value             |
+| itemDeselected | any          | Event that is fired when the item is deselected. The payload (`$event`) will be the item's value           |
 
 Example:
 
 ```
-<dts-select-container (select)="someMethod($event)">
+<dts-select-container (select)="someMethod($event)" (itemSelected)="itemSelected($event)" (itemDeselected)="itemDeselected($event)">
   ...
 </dts-select-container>
 ```

--- a/projects/ngx-drag-to-select/src/lib/select-container.component.ts
+++ b/projects/ngx-drag-to-select/src/lib/select-container.component.ts
@@ -108,8 +108,15 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
 
   @Output()
   selectedItemsChange = new EventEmitter<any>();
+
   @Output()
   select = new EventEmitter<any>();
+
+  @Output()
+  itemSelected = new EventEmitter<any>();
+
+  @Output()
+  itemDeselected = new EventEmitter<any>();
 
   private _tmpItems = new Map<SelectItemDirective, Action>();
 
@@ -283,12 +290,12 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
         switch (update.type) {
           case UpdateActions.Add:
             if (this._addItem(item, selectedItems)) {
-              item.select();
+              item._select();
             }
             break;
           case UpdateActions.Remove:
             if (this._removeItem(item, selectedItems)) {
-              item.deselect();
+              item._deselect();
             }
             break;
         }
@@ -433,7 +440,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
       (!inSelection && !item.selected && this.shortcuts.removeFromSelection(event) && this._tmpItems.has(item));
 
     if (shoudlAdd) {
-      item.selected ? item.deselect() : item.select();
+      item.selected ? item._deselect() : item._select();
 
       const action = this.shortcuts.removeFromSelection(event)
         ? Action.Delete
@@ -443,7 +450,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
 
       this._tmpItems.set(item, action);
     } else if (shouldRemove) {
-      this.shortcuts.removeFromSelection(event) ? item.select() : item.deselect();
+      this.shortcuts.removeFromSelection(event) ? item._select() : item._deselect();
       this._tmpItems.delete(item);
     }
   }
@@ -469,6 +476,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
       success = true;
       selectedItems.push(item.value);
       this._selectedItems$.next(selectedItems);
+      this.itemSelected.emit(item.value);
     }
 
     return success;
@@ -483,6 +491,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
       success = true;
       selectedItems.splice(index, 1);
       this._selectedItems$.next(selectedItems);
+      this.itemDeselected.emit(item.value);
     }
 
     return success;

--- a/projects/ngx-drag-to-select/src/lib/select-item.directive.ts
+++ b/projects/ngx-drag-to-select/src/lib/select-item.directive.ts
@@ -1,5 +1,18 @@
-import { Directive, DoCheck, ElementRef, Inject, Input, OnInit, Renderer2, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+
+import {
+  Directive,
+  DoCheck,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  OnInit,
+  Output,
+  PLATFORM_ID,
+  Renderer2
+} from '@angular/core';
+
 import { DragToSelectConfig } from './models';
 import { CONFIG } from './tokens';
 import { calculateBoundingClientRect } from './utils';
@@ -44,16 +57,16 @@ export class SelectItemDirective implements OnInit, DoCheck {
     return this._boundingClientRect;
   }
 
-  select() {
+  calculateBoundingClientRect() {
+    this._boundingClientRect = calculateBoundingClientRect(this.host.nativeElement);
+  }
+
+  _select() {
     this.selected = true;
   }
 
-  deselect() {
+  _deselect() {
     this.selected = false;
-  }
-
-  calculateBoundingClientRect() {
-    this._boundingClientRect = calculateBoundingClientRect(this.host.nativeElement);
   }
 
   private applySelectedClass() {


### PR DESCRIPTION
Adds `itemSelected` and `itemDeselected` output to `SelectContainerComponent`. Both carry the item value as payload.

Closes #35