### PR TITLE
fix(lib): only emit left mouse drag

### DIFF
--- a/cypress/integration/demo-page.spec.ts
+++ b/cypress/integration/demo-page.spec.ts
@@ -31,7 +31,7 @@ describe('Desktop', () => {
     it(`should add class '${NO_SELECT_CLASS}' to body on mousedown`, () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .get('@body')
           .should('have.class', NO_SELECT_CLASS);
       });
@@ -41,7 +41,7 @@ describe('Desktop', () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
           .as('start')
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .get('@body')
           .should('have.class', NO_SELECT_CLASS)
           .get('@start')
@@ -54,12 +54,12 @@ describe('Desktop', () => {
     it(`should add '${SELECTED_CLASS}' class to selected elements`, () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .should('have.class', SELECTED_CLASS);
 
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .getSelectItem(2)
           .dispatch('mousemove', 'bottomRight', { force: true })
           .dispatch('mouseup')
@@ -71,7 +71,7 @@ describe('Desktop', () => {
     it('should apply default styles', () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .then($element => {
             expect($element.css('box-shadow')).not.to.eq('none');
@@ -108,13 +108,13 @@ describe('Desktop', () => {
     it('should select single item on mousedown', () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .shouldSelect([1])
           .get(`.${SELECTED_CLASS}`)
           .should('have.length', 1)
           .getSelectItem(1)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .shouldSelect([2])
           .get(`.${SELECTED_CLASS}`)
@@ -126,7 +126,7 @@ describe('Desktop', () => {
       getDesktopExample().within(() => {
         enableSelectWithShortcut();
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .shouldSelect([])
           .get(`.${SELECTED_CLASS}`)
@@ -140,13 +140,13 @@ describe('Desktop', () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
           .as('end')
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .shouldSelect([1])
           .get(`.${SELECTED_CLASS}`)
           .should('have.length', 1)
           .get('@end')
-          .dispatch('mousedown', mousePosition)
+          .dispatch('mousedown', mousePosition, { button: 0 })
           .dispatch('mouseup', mousePosition)
           .shouldSelect([1])
           .get(`.${SELECTED_CLASS}`)
@@ -157,13 +157,13 @@ describe('Desktop', () => {
     it('should clear selected item when clicked inside draggable area', () => {
       getDesktopExample().within(() => {
         cy.getSelectItem(0)
-          .dispatch('mousedown')
+          .dispatch('mousedown', { button: 0 })
           .dispatch('mouseup')
           .shouldSelect([1])
           .get(`.${SELECTED_CLASS}`)
           .should('have.length', 1)
           .getSelectContainer()
-          .dispatch('mousedown', 'topLeft', { force: true })
+          .dispatch('mousedown', 'topLeft', { button: 0, force: true })
           .dispatch('mouseup', 'topLeft', { force: true })
           .shouldSelect([])
           .get(`.${SELECTED_CLASS}`)
@@ -176,7 +176,7 @@ describe('Desktop', () => {
     describe('Select on Drag', () => {
       it('should not start dragging if mouse is outside of draggable area', () => {
         cy.get('body')
-          .dispatch('mousedown', 'topLeft')
+          .dispatch('mousedown', 'topLeft', { button: 0 })
           .then(getDesktopExample)
           .within(() => {
             cy.getSelectItem(6, 'end')
@@ -192,13 +192,13 @@ describe('Desktop', () => {
       it('should start new selection', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(2)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(7)
             .dispatch('mousemove')
             .dispatch('mouseup')
             .shouldSelect([3, 4, 7, 8])
             .getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(1)
             .dispatch('mousemove', 'bottomRight', { force: true })
             .dispatch('mouseup')
@@ -209,7 +209,7 @@ describe('Desktop', () => {
       it('should select items when select box is positive', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(6, 'end')
             .dispatch('mousemove')
             .shouldSelect([1, 2, 3, 5, 6, 7])
@@ -223,7 +223,7 @@ describe('Desktop', () => {
       it('should select items when select box is negative', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(7)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(1, 'end')
             .dispatch('mousemove')
             .shouldSelect([2, 3, 4, 6, 7, 8])
@@ -238,7 +238,7 @@ describe('Desktop', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
             .as('end')
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .dispatch('mousemove', { clientX: 900, clientY: -100 })
             .shouldSelect([1, 2, 3, 4])
             .getSelectBox()
@@ -257,7 +257,7 @@ describe('Desktop', () => {
       it('should not select items while dragging', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(6, 'end')
             .dispatch('mousemove')
             .shouldSelect([1])
@@ -269,7 +269,7 @@ describe('Desktop', () => {
       it('should select items only after mouseup', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(6, 'end')
             .dispatch('mousemove')
             .shouldSelect([1])
@@ -287,7 +287,7 @@ describe('Desktop', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(5)
             .as('end')
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .dispatch('mousemove', mousePosition)
             .shouldSelect([6])
             .get('@end')
@@ -308,7 +308,7 @@ describe('Desktop', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
             .as('end')
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .shouldSelect([])
             .get(`.${SELECTED_CLASS}`)
             .should('have.length', 0)
@@ -322,7 +322,7 @@ describe('Desktop', () => {
       it('should not select item while dragging', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(2)
             .as('end')
             .dispatch('mousemove')
@@ -339,7 +339,57 @@ describe('Desktop', () => {
       it('should not select item on mouseup', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
+            .getSelectItem(2)
+            .as('end')
+            .dispatch('mousemove')
+            .get('@end')
+            .dispatch('mouseup')
+            .get(`.${SELECTED_CLASS}`)
+            .should('have.length', 0)
+            .getSelectBox()
+            .then(shouldBeInvisible);
+        });
+      });
+    });
+
+    describe('Right mouse drag', () => {
+      it('should not select item on mousedown', () => {
+        getDesktopExample().within(() => {
+          cy.getSelectItem(0)
+            .as('end')
+            .dispatch('mousedown', { button: 2 })
+            .shouldSelect([])
+            .get(`.${SELECTED_CLASS}`)
+            .should('have.length', 0)
+            .getSelectBox()
+            .then(shouldBeInvisible)
+            .get('@end')
+            .dispatch('mouseup');
+        });
+      });
+
+      it('should not select item while dragging', () => {
+        getDesktopExample().within(() => {
+          cy.getSelectItem(0)
+            .dispatch('mousedown', { button: 2 })
+            .getSelectItem(2)
+            .as('end')
+            .dispatch('mousemove')
+            .shouldSelect([])
+            .get(`.${SELECTED_CLASS}`)
+            .should('have.length', 0)
+            .getSelectBox()
+            .then(shouldBeInvisible)
+            .get('@end')
+            .dispatch('mouseup');
+        });
+      });
+
+      it('should not select item on mouseup', () => {
+        getDesktopExample().within(() => {
+          cy.getSelectItem(0)
+            .dispatch('mousedown', { button: 2 })
             .getSelectItem(2)
             .as('end')
             .dispatch('mousemove')
@@ -363,19 +413,19 @@ describe('Desktop', () => {
         it('should toggle single items', () => {
           getDesktopExample().within(() => {
             cy.getSelectItem(0)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .getSelectItem(1)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .getSelectItem(2)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .shouldSelect([1, 2, 3])
               .get(`.${SELECTED_CLASS}`)
               .should('have.length', 3)
               .getSelectItem(1)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .shouldSelect([1, 3])
               .get(`.${SELECTED_CLASS}`)
@@ -386,7 +436,7 @@ describe('Desktop', () => {
         it('should now allow dragging', () => {
           getDesktopExample().within(() => {
             cy.getSelectItem(0)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .getSelectItem(6)
               .as('end')
               .dispatch('mousemove')
@@ -405,7 +455,7 @@ describe('Desktop', () => {
         it('should toggle items when selectOnDrag is false', () => {
           getDesktopExample().within(() => {
             cy.getSelectItem(0)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .getSelectItem(5)
               .as('end')
               .dispatch('mousemove')
@@ -416,7 +466,7 @@ describe('Desktop', () => {
               .should('have.length', 4);
 
             cy.getSelectItem(0)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .shouldSelect([1])
               .get(`.${SELECTED_CLASS}`)
@@ -426,7 +476,7 @@ describe('Desktop', () => {
             disableSelectOnDrag();
 
             cy.getSelectItem(1)
-              .dispatch('mousedown')
+              .dispatch('mousedown', { button: 0 })
               .dispatch('mouseup')
               .shouldSelect([1, 2])
               .get(`.${SELECTED_CLASS}`)
@@ -457,13 +507,13 @@ describe('Desktop', () => {
       it('should extend selection after mouseup', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(5)
             .dispatch('mousemove')
             .dispatch('mouseup')
             .shouldSelect([1, 2, 5, 6])
             .getSelectItem(2)
-            .dispatch('mousedown', { shiftKey: true })
+            .dispatch('mousedown', { button: 0, shiftKey: true })
             .getSelectItem(7)
             .as('end')
             .dispatch('mousemove', { shiftKey: true })
@@ -481,14 +531,20 @@ describe('Desktop', () => {
       it('should remove items from selection after mouseup', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown')
+            .dispatch('mousedown', { button: 0 })
             .getSelectItem(5)
             .as('removeStart')
             .dispatch('mousemove')
             .dispatch('mouseup')
             .shouldSelect([1, 2, 5, 6])
             .get('@removeStart')
-            .dispatch('mousedown', 'bottomRight', { force: true, shiftKey: true, ctrlKey: true, metaKey: true })
+            .dispatch('mousedown', 'bottomRight', {
+              button: 0,
+              force: true,
+              shiftKey: true,
+              ctrlKey: true,
+              metaKey: true
+            })
             .shouldSelect([1, 2, 5, 6])
             .getSelectItem(1)
             .as('end')
@@ -507,7 +563,7 @@ describe('Desktop', () => {
       it('should disable selection', () => {
         getDesktopExample().within(() => {
           cy.getSelectItem(0)
-            .dispatch('mousedown', { altKey: true })
+            .dispatch('mousedown', { button: 0, altKey: true })
             .getSelectItem(11)
             .as('end')
             .dispatch('mousemove')
@@ -535,7 +591,7 @@ describe('Mobile', () => {
         .should('have.length', 1)
         .getSelectItem(0)
         .as('end')
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .then($element => {
           expect($element.css('box-shadow')).to.eq('none');
           expect($element.css('border-width')).to.eq('0px');
@@ -548,7 +604,7 @@ describe('Mobile', () => {
   it('should not select items while dragging', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .getSelectItem(4)
         .dispatch('mousemove', 'bottomRight', { force: true })
         .getSelectBox()
@@ -563,13 +619,13 @@ describe('Mobile', () => {
   it('should select multiple items on click', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .getSelectItem(1)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .getSelectItem(4)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(getSelectCount)
         .should('contain', 3)
@@ -582,7 +638,7 @@ describe('Mobile', () => {
     getMobileExample().within(() => {
       cy.then(shouldBeInSelectMode(false))
         .getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(shouldBeInSelectMode());
     });
@@ -592,11 +648,11 @@ describe('Mobile', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
         .as('item')
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(shouldBeInSelectMode())
         .get('@item')
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(shouldBeInSelectMode(false));
     });
@@ -605,7 +661,7 @@ describe('Mobile', () => {
   it('should select all', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(selectAll)
         .then(getSelectCount)
@@ -618,7 +674,7 @@ describe('Mobile', () => {
   it('should delete all items', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(selectAll)
         .then(deleteItems)
@@ -635,7 +691,7 @@ describe('Mobile', () => {
         .get('.dts-select-item')
         .should('have.length', 13)
         .getSelectItem(12)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(getSelectCount)
         .should('contain', 1)
@@ -647,10 +703,10 @@ describe('Mobile', () => {
   it('should cancel selection', () => {
     getMobileExample().within(() => {
       cy.getSelectItem(0)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .getSelectItem(2)
-        .dispatch('mousedown')
+        .dispatch('mousedown', { button: 0 })
         .dispatch('mouseup')
         .then(getSelectCount)
         .as('selectCount')

--- a/cypress/support/utils.ts
+++ b/cypress/support/utils.ts
@@ -85,7 +85,7 @@ export const clearSelection = () => {
 export const toggleItem = (subject: Cypress.ObjectLike) => {
   return cy
     .wrap(subject)
-    .dispatch('mousedown', { ctrlKey: true, metaKey: true })
+    .dispatch('mousedown', { button: 0, ctrlKey: true, metaKey: true })
     .dispatch('mouseup');
 };
 

--- a/projects/ngx-drag-to-select/src/lib/select-container.component.ts
+++ b/projects/ngx-drag-to-select/src/lib/select-container.component.ts
@@ -153,16 +153,17 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy {
         share()
       );
 
-      const mousedown$ = fromEvent(this.host, 'mousedown').pipe(
+      const mousedown$ = fromEvent<MouseEvent>(this.host, 'mousedown').pipe(
+        filter(event => event.button === 0), // only emit left mouse
         filter(() => !this.disabled),
-        tap((event: MouseEvent) => this._onMouseDown(event)),
+        tap(event => this._onMouseDown(event)),
         share()
       );
 
       const dragging$ = mousedown$.pipe(
         filter(event => !this.shortcuts.disableSelection(event)),
-        filter(event => !this.selectMode),
-        filter(event => !this.disableDrag),
+        filter(() => !this.selectMode),
+        filter(() => !this.disableDrag),
         switchMap(() => mousemove$.pipe(takeUntil(mouseup$))),
         share()
       );


### PR DESCRIPTION
BREAKING CHANGE:

BEFORE:
It was possible to drag with all (left, right, middle) mouse buttons

AFTER:
It is only possible to drag with the left mouse button


## Extra information

- Changed every mousedown event in cypress to be a left mouse click; Perhaps adding it in `dispatch` would be cleaner, although not visible for newcomers?
- Changed the `precommit` script, because it's giving errors on a windows machine - https://github.com/marionebl/commitlint/pull/343

Closes #53.
