### PR TITLE
feat(lib): add classes for selection modes

### DIFF
--- a/projects/ngx-drag-to-select/src/lib/shortcut.service.ts
+++ b/projects/ngx-drag-to-select/src/lib/shortcut.service.ts
@@ -32,23 +32,23 @@ export class ShortcutService {
     this._shortcuts = this.createShortcutsFromConfig(config.shortcuts);
   }
 
-  disableSelection(event: MouseEvent) {
+  disableSelection(event: Event) {
     return this.isShortcutPressed('disableSelection', event);
   }
 
-  toggleSingleItem(event: MouseEvent) {
+  toggleSingleItem(event: Event) {
     return this.isShortcutPressed('toggleSingleItem', event);
   }
 
-  addToSelection(event: MouseEvent) {
+  addToSelection(event: Event) {
     return this.isShortcutPressed('addToSelection', event);
   }
 
-  removeFromSelection(event: MouseEvent) {
+  removeFromSelection(event: Event) {
     return this.isShortcutPressed('removeFromSelection', event);
   }
 
-  extendedSelectionShortcut(event: MouseEvent) {
+  extendedSelectionShortcut(event: Event) {
     return this.addToSelection(event) || this.removeFromSelection(event);
   }
 
@@ -107,7 +107,7 @@ export class ShortcutService {
     return `${ERROR_PREFIX} ${message}`;
   }
 
-  private isShortcutPressed(shortcutName: string, event: MouseEvent) {
+  private isShortcutPressed(shortcutName: string, event: Event) {
     const shortcuts = this._shortcuts[shortcutName];
 
     return shortcuts.some(shortcut => {

--- a/projects/ngx-drag-to-select/src/scss/mixins.scss
+++ b/projects/ngx-drag-to-select/src/scss/mixins.scss
@@ -1,0 +1,4 @@
+@mixin styleSelectBox($background-color, $border-color: currentColor) {
+  background: rgba($background-color, 0.3);
+  border: $select-box-border-size solid $border-color;
+}

--- a/projects/ngx-drag-to-select/src/scss/ngx-drag-to-select.scss
+++ b/projects/ngx-drag-to-select/src/scss/ngx-drag-to-select.scss
@@ -1,16 +1,17 @@
 @import 'variables';
+@import 'mixins';
 
 .dts-no-select {
   user-select: none;
 }
 
 .dts-select-box {
+  @include styleSelectBox($select-box-color);
+
   contain: layout;
   transform: translateZ(0);
   box-sizing: border-box;
   color: $select-box-color;
-  background: rgba($select-box-color, 0.3);
-  border: $select-box-border-size solid currentColor;
   position: absolute;
   left: 0;
   top: 0;
@@ -19,6 +20,10 @@
   pointer-events: none;
   opacity: 0;
   z-index: 1;
+
+  &.dts-removing {
+    @include styleSelectBox($select-box-removing-color, $select-box-removing-color);
+  }
 }
 
 .dts-select-container:not(.dts-custom) {

--- a/projects/ngx-drag-to-select/src/scss/variables.scss
+++ b/projects/ngx-drag-to-select/src/scss/variables.scss
@@ -1,5 +1,8 @@
-$select-box-color: #7ddafc !default;
+$dts-primary: #7ddafc !default;
+
+$select-box-color: $dts-primary !default;
 $select-box-border-size: 2px !default;
+$select-box-removing-color: $dts-primary !default;
 
 $selected-item-border: true !default;
 $selected-item-border-color: #d2d2d2 !default;


### PR DESCRIPTION
This feature introduces two classes - dts-adding and dts-removing - which are
added to the select box element for more flexibility in styling. In addition,
the color of the select box when in removing mode can now be styled with a
separate variable '$select-box-removing-color'. If the color should be the same
for both adding and removing, the '$dts-primary' variable can be used.

Fixes #52