### PR TITLE
feat(lib): add selection outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,13 @@ Here's an example of all inputs in action:
 
 **Outputs**
 
-| Input          | Payload Type | Description                                                                                                |
-| -------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
-| select         | Array<any>   | Event that is fired when the selection changes. The payload (`$event`) will be the list of selected items. |
-| itemSelected   | any          | Event that is fired when the item is selected. The payload (`$event`) will be the item's value             |
-| itemDeselected | any          | Event that is fired when the item is deselected. The payload (`$event`) will be the item's value           |
+| Input            | Payload Type | Description                                                                                                                                        |
+| ---------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| select           | Array<any>   | Event that is fired when the selection changes. The payload (`$event`) will be the list of selected items.                                         |
+| itemSelected     | any          | Event that is fired when the item is selected. The payload (`$event`) will be the item's value                                                     |
+| itemDeselected   | any          | Event that is fired when the item is deselected. The payload (`$event`) will be the item's value                                                   |
+| selectionStarted | None         | Event that is fired when the user starts selecting items.                                                                                          |
+| selectionEnded   | Array<any>   | Event that is fired when the user stops selecting items, typically by releasing the mouse button. The payload will be a list of all selected items |
 
 Example:
 
@@ -506,11 +508,7 @@ Suppose, we have the following markup:
 ```html
 <body>
   ...
-  <div class="scrollable">
-    <dts-select-container #container="dts-select-container">
-      ...
-    </dts-select-container>
-  </div>
+  <div class="scrollable"><dts-select-container #container="dts-select-container"> ... </dts-select-container></div>
 </body>
 ```
 
@@ -522,9 +520,7 @@ Check out the solution to the problem:
 <body>
   ...
   <div class="scrollable" (scroll)="container.update()">
-    <dts-select-container #container="dts-select-container">
-      ...
-    </dts-select-container>
+    <dts-select-container #container="dts-select-container"> ... </dts-select-container>
   </div>
 </body>
 ```

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,15 +4,11 @@
     <h3>Keyboard Shortcuts</h3>
     <mat-tab-group [@.disabled]="true">
       <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon svgIcon="apple"></mat-icon>
-        </ng-template>
+        <ng-template mat-tab-label> <mat-icon svgIcon="apple"></mat-icon> </ng-template>
         <app-shortcuts os="mac"></app-shortcuts>
       </mat-tab>
       <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon svgIcon="windows"></mat-icon>
-        </ng-template>
+        <ng-template mat-tab-label> <mat-icon svgIcon="windows"></mat-icon> </ng-template>
         <app-shortcuts os="windows"></app-shortcuts>
       </mat-tab>
     </mat-tab-group>
@@ -20,8 +16,7 @@
 
   <section data-cy="desktop" *ngIf="isDesktop">
     <h3>
-      <span>Desktop Demo</span>
-      <a href="https://github.com/d3lm/ngx-drag-to-select/blob/master/src/app">SOURCE</a>
+      <span>Desktop Demo</span> <a href="https://github.com/d3lm/ngx-drag-to-select/blob/master/src/app">SOURCE</a>
     </h3>
 
     <mat-checkbox data-cy="selectOnDrag" [(ngModel)]="selectOnDrag">Select on Drag</mat-checkbox>
@@ -30,11 +25,19 @@
     <mat-checkbox data-cy="selectWithShortcut" [(ngModel)]="selectWithShortcut">Select with Shortcut</mat-checkbox>
 
     <button data-cy="selectAll" mat-raised-button (click)="selectContainer.selectAll()">Select All</button>
-    <button data-cy="clearSelection" mat-raised-button (click)="selectContainer.clearSelection()">Clear Selection</button>
+    <button data-cy="clearSelection" mat-raised-button (click)="selectContainer.clearSelection()">
+      Clear Selection
+    </button>
 
     <div class="drag-area">
-      <dts-select-container #selectContainer="dts-select-container" [selectMode]="selectMode" [(selectedItems)]="selectedDocuments"
-        [disabled]="disable" [selectOnDrag]="selectOnDrag" [selectWithShortcut]="selectWithShortcut" (select)="onSelect($event)">
+      <dts-select-container
+        #selectContainer="dts-select-container"
+        [selectMode]="selectMode"
+        [(selectedItems)]="selectedDocuments"
+        [disabled]="disable"
+        [selectOnDrag]="selectOnDrag"
+        [selectWithShortcut]="selectWithShortcut"
+      >
         <mat-grid-list cols="4" rowHeight="200px" gutterSize="20px">
           <mat-grid-tile [dtsSelectItem]="document" *ngFor="let document of documents">
             {{ document.name }}
@@ -46,8 +49,7 @@
     <div class="meta">
       <h4>Meta Information</h4>
       <div>
-        <label>Selected</label>
-        <span data-cy="select-count">{{ selectedDocuments.length }}</span>
+        <label>Selected</label> <span data-cy="select-count">{{ selectedDocuments.length }}</span>
       </div>
       <ul class="selected-items">
         <li data-cy="selected-item" class="selected-item" *ngFor="let item of selectedDocuments">{{ item.name }}</li>
@@ -57,13 +59,10 @@
 
   <section data-cy="mobile">
     <h3>
-      <span>Mobile Demo</span>
-      <a href="https://github.com/d3lm/ngx-drag-to-select/blob/master/src/app/phone">SOURCE</a>
+      <span>Mobile Demo</span> <a href="https://github.com/d3lm/ngx-drag-to-select/blob/master/src/app/phone">SOURCE</a>
     </h3>
 
-    <div class="mobile-wrapper">
-      <app-phone></app-phone>
-    </div>
+    <div class="mobile-wrapper"><app-phone></app-phone></div>
   </section>
 </main>
 <app-footer></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -49,8 +49,4 @@ export class AppComponent implements OnInit {
       });
     }
   }
-
-  onSelect(items: Array<any>) {
-    // Do something with the selected items
-  }
 }


### PR DESCRIPTION
This commit adds two outputs to the select-container - `selectionStarted` and `selectionEnded`. This helps with better and more efficient  processing of selected items. There is `select` but this output is emitted with each and every selected item. For large collections this is quite inefficient. With the new outputs this becomes much better.

Closes #64