### PR TITLE
fix(ivy): ensure the package can be built with ivy

### DIFF
--- a/projects/ngx-drag-to-select/src/lib/drag-to-select.module.ts
+++ b/projects/ngx-drag-to-select/src/lib/drag-to-select.module.ts
@@ -9,16 +9,14 @@ import { CONFIG, USER_CONFIG } from './tokens';
 import { DEFAULT_CONFIG } from './config';
 import { mergeDeep } from './utils';
 
-const COMPONENTS = [SelectContainerComponent, SelectItemDirective];
-
 export function CONFIG_FACTORY(config: Partial<DragToSelectConfig>) {
   return mergeDeep(DEFAULT_CONFIG, config);
 }
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [...COMPONENTS],
-  exports: [...COMPONENTS]
+  declarations: [SelectContainerComponent, SelectItemDirective],
+  exports: [SelectContainerComponent, SelectItemDirective]
 })
 export class DragToSelectModule {
   static forRoot(config: Partial<DragToSelectConfig> = {}): ModuleWithProviders {


### PR DESCRIPTION
Hey @d3lm! 👋 

Whilst playing with ivy I found that this module won't currently compile with it because of the usage of the spread operator to define the module declarations and exports. There is a fix in the works though to resolve this on the angular side, so maybe it's better to just wait for that to land: https://github.com/angular/angular/pull/30492