### PR TITLE
fix(lib): make selecting boundary relative

### DIFF
--- a/projects/ngx-drag-to-select/src/lib/select-container.component.ts
+++ b/projects/ngx-drag-to-select/src/lib/select-container.component.ts
@@ -409,7 +409,7 @@ export class SelectContainerComponent implements AfterViewInit, OnDestroy, After
       return;
     }
 
-    const mousePoint = getMousePosition(event);
+    const mousePoint = getRelativeMousePosition(event);
     const [currentIndex, clickedItem] = this._getClosestSelectItem(event);
 
     let [startIndex, endIndex] = this._lastRange;


### PR DESCRIPTION
Hey everyone,
I had the problem, when using this in an absolute scrolling container, and the container has moves (e.g. style.left = -2323px or transform: scale(0.23)), the selecting container does not react to it.

Is there a possibility to integrate the output of my branch into my current project for testing?
